### PR TITLE
Fix: 404 registry.npmjs package not found

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,6 +10,7 @@ if [ -n "$NPM_AUTH_TOKEN" ]; then
   # Allow registry.npmjs.org to be overridden with an environment variable
   printf "//%s/:_authToken=%s\\nregistry=%s" "$NPM_REGISTRY_URL" "$NPM_AUTH_TOKEN" "$NPM_REGISTRY_URL" > "$NPM_CONFIG_USERCONFIG"
   chmod 0600 "$NPM_CONFIG_USERCONFIG"
+  npm config set registry https://registry.npmjs.org/
 fi
 
 exec "$@"


### PR DESCRIPTION
Seems as though the default npm registry is set to:
```
registry="registry.npmjs.org"
```

which gave a warning:
```
npm WARN invalid config registry="registry.npmjs.org"
npm WARN invalid config Must be a full url with 'http://'
```
Setting registry to https://registry.npmjs.org/ fixes this issue